### PR TITLE
Unique message ids based on moment()

### DIFF
--- a/src/javascripts/components/messagesDisplay/messagesDisplay.js
+++ b/src/javascripts/components/messagesDisplay/messagesDisplay.js
@@ -17,6 +17,7 @@ const messageBuilder = () => {
     domString += '</div>';
   });
 
+
   utils.printToDom('message-container', domString);
 };
 

--- a/src/javascripts/main.js
+++ b/src/javascripts/main.js
@@ -8,12 +8,14 @@ import 'bootstrap';
 import '@fortawesome/fontawesome-free';
 import '../styles/main.scss';
 
+
 const moment = require('moment');
 
 const addMessage = (e) => {
   const allMessages = messageData.getMessages();
   if (e.which === 13) {
     e.preventDefault();
+
     let messageInput = $('#message-input').val();
     messageInput = messageInput.replace(/:smile:/g, '😊');
     messageInput = messageInput.replace(/:laugh:/g, '😂');
@@ -21,8 +23,10 @@ const addMessage = (e) => {
     messageInput = messageInput.replace(/:thumbsdown:/g, '👎');
     messageInput = messageInput.replace(/:coronavirus:/g, '😷');
 
+    const messageId = `message${moment().format('mmss')}`;
+
     const messageObject = {
-      id: `message${allMessages.length + 1}`,
+      id: messageId,
       name: users.selectName(),
       userId: users.selectId(),
       message: messageInput,
@@ -33,6 +37,7 @@ const addMessage = (e) => {
     };
     messageData.setMessages(messageObject);
     $('#message-input').val('');
+    console.error(messageObject.id);
   }
 
   messagesDisplay.messageBuilder();


### PR DESCRIPTION
This resolves the issue where the message id is the same when the messages array caps off at 20. 

Using the old method is the array stays at 20, then every new message will have the same id `message21`

Using `moment().format('mmss')` I was able to resolve this, BUT this creates a new more minor bug.

When you create more than one message within a second, then they will have the same message id.

Fortunately, there are very rare occasions when two messages can be typed within the second.